### PR TITLE
feat(performance): Always inline certain small methods

### DIFF
--- a/src/sha256.nr
+++ b/src/sha256.nr
@@ -6,7 +6,7 @@ use constants::{
     INT_SIZE_PTR, MSG_BLOCK, MSG_SIZE_PTR, STATE, TWO_POW_16, TWO_POW_24, TWO_POW_32, TWO_POW_8,
 };
 
-pub(crate) mod constants;
+mod constants;
 mod tests;
 
 // Implementation of SHA-256 mapping a byte array of variable length to

--- a/src/sha256.nr
+++ b/src/sha256.nr
@@ -6,7 +6,7 @@ use constants::{
     INT_SIZE_PTR, MSG_BLOCK, MSG_SIZE_PTR, STATE, TWO_POW_16, TWO_POW_24, TWO_POW_32, TWO_POW_8,
 };
 
-mod constants;
+pub(crate) mod constants;
 mod tests;
 
 // Implementation of SHA-256 mapping a byte array of variable length to
@@ -335,6 +335,7 @@ fn verify_msg_block_equals_last(
 }
 
 // Set the rightmost `zeros` number of bytes to 0.
+#[inline_always]
 fn set_item_zeros(item: u32, zeros: u8) -> u32 {
     lshift8(rshift8(item, zeros), zeros)
 }
@@ -360,6 +361,7 @@ fn get_item_byte(mut msg_item: u32, msg_byte_ptr: BLOCK_BYTE_PTR) -> u8 {
 // Project a byte into a position in a field based on the overall block pointer.
 // For example putting 1 into pointer 5 would be 100, because overall we would
 // have [____, 0100] with indexes [0123,4567].
+#[inline_always]
 fn byte_into_item(msg_byte: u8, msg_byte_ptr: BLOCK_BYTE_PTR) -> u32 {
     let mut msg_item = msg_byte as u32;
     // How many times do we have to shift to the left to get to the position we want?
@@ -369,6 +371,7 @@ fn byte_into_item(msg_byte: u8, msg_byte_ptr: BLOCK_BYTE_PTR) -> u32 {
 }
 
 // Construct a field out of 4 bytes.
+#[inline_always]
 fn make_item(b0: u8, b1: u8, b2: u8, b3: u8) -> u32 {
     let mut item = b0 as u32;
     item = lshift8(item, 1) + b1 as u32;
@@ -380,6 +383,7 @@ fn make_item(b0: u8, b1: u8, b2: u8, b3: u8) -> u32 {
 // Shift by 8 bits to the left between 0 and 4 times.
 // Checks `is_unconstrained()` to just use a bitshift if we're running in an unconstrained context,
 // otherwise multiplies by 256.
+#[inline_always]
 fn lshift8(item: u32, shifts: u8) -> u32 {
     if is_unconstrained() {
         // Brillig wouldn't shift 0<<4 without overflow.


### PR DESCRIPTION
# Description

## Problem\*

Part of general effort to reduce Brillig bytecode sizes and execution trace

## Summary\*

Certain small methods like `lshift8` are called repeatedly but in fact do very little:
These are the internals of `lshift8` in an unconstrained context.
```
if is_unconstrained() {
        if item == 0 {
            0
        } else {
            // Brillig wouldn't shift 0<<4 without overflow.
            item << (8 * shifts)
        }
    }
```
We can avoid the function call overhead for this method that is itself only a few instructions and is likely to be simplified further as `shifts` is often a constant.

## Additional Context



# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
