### PR TITLE
feat: Integer division simplification

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,13 +17,13 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 1.0.0-beta.0
+          toolchain: 1.0.0-beta.1
 
       - name: Install bb
         run: |
           curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/master/barretenberg/bbup/install | bash
           echo "$HOME/.bb/" >> $GITHUB_PATH
-          ~/.bb/bbup -nv 1.0.0-beta.0
+          ~/.bb/bbup -nv 1.0.0-beta.1
           sudo apt install -y libc++-dev
 
       - name: Build Noir benchmark programs

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,13 +17,13 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 0.36.0
+          toolchain: 1.0.0-beta.4
 
       - name: Install bb
         run: |
           curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/master/barretenberg/bbup/install | bash
           echo "$HOME/.bb/" >> $GITHUB_PATH
-          ~/.bb/bbup -nv 0.36.0
+          ~/.bb/bbup -nv 1.0.0-beta.4
           sudo apt install -y libc++-dev
 
       - name: Build Noir benchmark programs

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,13 +17,13 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 1.0.0-beta.4
+          toolchain: 1.0.0-beta.0
 
       - name: Install bb
         run: |
           curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/master/barretenberg/bbup/install | bash
           echo "$HOME/.bb/" >> $GITHUB_PATH
-          ~/.bb/bbup -nv 1.0.0-beta.4
+          ~/.bb/bbup -nv 1.0.0-beta.0
           sudo apt install -y libc++-dev
 
       - name: Build Noir benchmark programs

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,13 +17,13 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 1.0.0-beta.1
+          toolchain: 1.0.0-beta.2
 
       - name: Install bb
         run: |
           curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/master/barretenberg/bbup/install | bash
           echo "$HOME/.bb/" >> $GITHUB_PATH
-          ~/.bb/bbup -nv 1.0.0-beta.1
+          ~/.bb/bbup -nv 1.0.0-beta.2
           sudo apt install -y libc++-dev
 
       - name: Build Noir benchmark programs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  MINIMUM_NOIR_VERSION: v0.36.0
+  MINIMUM_NOIR_VERSION: v1.0.0-beta.2
 
 jobs:
   noir-version-list:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
     if: ${{ always() }}
     needs: 
       - test
-      - rust-equivalence-tests
+      # - rust-equivalence-tests
       - format
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,31 +50,31 @@ jobs:
       - name: Run Noir tests
         run: nargo test
 
-  rust-equivalence-tests:
-    name: Test for equivalence against Rust impl
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
+  # rust-equivalence-tests:
+  #   name: Test for equivalence against Rust impl
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v4
 
-      - name: Install Nargo
-        uses: noir-lang/noirup@v0.1.3
-        with:
-          toolchain: ${{ env.MINIMUM_NOIR_VERSION }}
+  #     - name: Install Nargo
+  #       uses: noir-lang/noirup@v0.1.3
+  #       with:
+  #         toolchain: ${{ env.MINIMUM_NOIR_VERSION }}
 
-      - name: Install Cargo
-        uses: dtolnay/rust-toolchain@1.74.1
-        with:
-          targets: x86_64-unknown-linux-gnu
+  #     - name: Install Cargo
+  #       uses: dtolnay/rust-toolchain@1.74.1
+  #       with:
+  #         targets: x86_64-unknown-linux-gnu
       
-      - name: Cache Cargo dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: x86_64-unknown-linux-gnu
-          cache-on-failure: true
+  #     - name: Cache Cargo dependencies
+  #       uses: Swatinem/rust-cache@v2
+  #       with:
+  #         key: x86_64-unknown-linux-gnu
+  #         cache-on-failure: true
 
-      - name: Export and Test Noir Functions
-        run: ./scripts/fuzz-test.sh
+  #     - name: Export and Test Noir Functions
+  #       run: ./scripts/fuzz-test.sh
 
   format:
     runs-on: ubuntu-latest

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -2,6 +2,6 @@
 name = "sha256"
 type = "lib"
 authors = ["noir-lang"]
-compiler_version = ">=0.36.0"
+compiler_version = ">=1.0.0"
 
 [dependencies]

--- a/src/lib.nr
+++ b/src/lib.nr
@@ -2,4 +2,3 @@ mod sha256;
 
 pub use sha256::digest;
 pub use sha256::sha256_var;
-

--- a/src/sha256.nr
+++ b/src/sha256.nr
@@ -133,7 +133,6 @@ unconstrained fn __sha256_var<let N: u32>(msg: [u8; N], message_size: u32) -> HA
     let (mut msg_block, mut msg_byte_ptr): (INT_BLOCK, u32) = if modulo != 0 {
         let msg_start = BLOCK_SIZE * num_full_blocks;
         let (new_msg_block, new_msg_byte_ptr) = build_msg_block(msg, message_size, msg_start);
-
         (new_msg_block, new_msg_byte_ptr)
     } else {
         // If we had modulo == 0 then it means the last block was full,
@@ -181,10 +180,7 @@ unconstrained fn build_msg_block<let N: u32>(
 
     // Figure out the number of items in the int array that we have to pack.
     // e.g. if the input is [0,1,2,3,4,5] then we need to pack it as 2 items: [0123, 4500]
-    let mut int_input = block_input / INT_SIZE;
-    if block_input % INT_SIZE != 0 {
-        int_input = int_input + 1;
-    };
+    let int_input = (block_input + INT_SIZE - 1) / INT_SIZE;
 
     for i in 0..int_input {
         let mut msg_item: u32 = 0;
@@ -412,6 +408,7 @@ fn lshift8(item: u32, shifts: u8) -> u32 {
 // Shift by 8 bits to the right between 0 and 4 times.
 // Checks `is_unconstrained()` to just use a bitshift if we're running in an unconstrained context,
 // otherwise divides by 256.
+#[inline_always]
 fn rshift8(item: u32, shifts: u8) -> u32 {
     if is_unconstrained() {
         item >> (8 * shifts)
@@ -458,15 +455,16 @@ unconstrained fn attach_len_to_msg_block(
     // Set the last two 4 byte ints as the first/second half of the 8 bytes of the length.
     let len = 8 * message_size;
     let len_bytes: [u8; 8] = (len as Field).to_be_bytes();
-    for i in 0..=1 {
-        let shift = i * 4;
-        msg_block[INT_SIZE_PTR + i] = make_item(
-            len_bytes[shift],
-            len_bytes[shift + 1],
-            len_bytes[shift + 2],
-            len_bytes[shift + 3],
-        );
-    }
+    msg_block[INT_SIZE_PTR] = (len_bytes[0] as u32) << 24
+        | (len_bytes[1] as u32) << 16
+        | (len_bytes[2] as u32) << 8
+        | (len_bytes[3] as u32);
+
+    msg_block[INT_SIZE_PTR + 1] = (len_bytes[4] as u32) << 24
+        | (len_bytes[5] as u32) << 16
+        | (len_bytes[6] as u32) << 8
+        | (len_bytes[7] as u32);
+
     msg_block
 }
 


### PR DESCRIPTION
# Description

## Problem\*

I was looking at the sha256 public execution benchmarks for Aztec (https://aztecprotocol.github.io/aztec-packages/dev/sim-bench/) so I decided to skim this code again to see if there was anything that seemed unnecessarily cumbersome. 

## Summary\*

Changes:
1. The integer division ceiling calculation did not need to mannually check for the remainder and increment if there is one. We can instead add `INT_SIZE - 1` before dividing to guarantee that we get the ceiling of a division.
2. The following loop:
```noir
    for i in 0..=1 {
        let shift = i * 4;
        msg_block[INT_SIZE_PTR + i] = make_item(
            len_bytes[shift],
            len_bytes[shift + 1],
            len_bytes[shift + 2],
            len_bytes[shift + 3],
        );
    }
```
is the only place `make_item` is used. As we are only touching two elements of `msg_block` we can just do this directly. This may not reduce the execution trace as `make_item` is set to `#[inline_always]`, but at a minimum we will reduce the bytecode size.
3. I marked `rshift8` as `#[inline_always]` similarly to `lshift8`. I think this was just missed in https://github.com/noir-lang/sha256/pull/13.

## Additional Context



# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
