### PR TITLE
feat: remove overflow checks in `verify_msg_len` function

### DIFF
--- a/src/sha256.nr
+++ b/src/sha256.nr
@@ -484,12 +484,12 @@ fn verify_msg_len(
     verify_msg_block_equals_last(msg_block, last_block, msg_byte_ptr);
 
     // We verify the message length was inserted correctly by reversing the byte decomposition.
-    let mut reconstructed_len: u64 = 0;
+    let mut reconstructed_len: Field = 0;
     for i in INT_SIZE_PTR..INT_BLOCK_SIZE {
-        reconstructed_len = reconstructed_len * TWO_POW_32;
-        reconstructed_len = reconstructed_len + msg_block[i] as u64;
+        reconstructed_len *= TWO_POW_32 as Field;
+        reconstructed_len += msg_block[i] as Field;
     }
-    let len = 8 * message_size as u64;
+    let len = 8 * message_size as Field;
     assert_eq(reconstructed_len, len);
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR removes some unnecessary overflow checks in `verify_msg_len`

## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
