### PR TITLE
chore: export partial hash functions

### DIFF
--- a/src/lib.nr
+++ b/src/lib.nr
@@ -1,9 +1,9 @@
 mod sha256;
 mod sha224;
 
+pub use sha224::partial_sha224_var_end;
 pub use sha224::sha224_var;
 pub use sha256::digest;
-pub use sha256::sha256_var;
-pub use sha224::partial_sha224_var_end;
 pub use sha256::partial_sha256_var_end;
 pub use sha256::partial_sha256_var_interstitial;
+pub use sha256::sha256_var;

--- a/src/sha256.nr
+++ b/src/sha256.nr
@@ -117,7 +117,7 @@ pub(crate) fn process_full_blocks<let N: u32>(
     for i in 0..num_blocks {
         let msg_start = BLOCK_SIZE * i;
         let (new_msg_block, new_msg_byte_ptr) =
-        // Safety: separate verification function
+            // Safety: separate verification function
             unsafe { build_msg_block(msg, message_size, msg_start) };
 
         if msg_start < message_size {
@@ -515,7 +515,7 @@ pub(crate) fn finalize_sha256_blocks<let N: u32>(
         let num_blocks = total_len / BLOCK_SIZE;
         let msg_start = BLOCK_SIZE * num_blocks;
         let (new_msg_block, new_msg_byte_ptr) =
-        // Safety: separate verification function
+            // Safety: separate verification function
             unsafe { build_msg_block(msg, message_size, msg_start) };
 
         if msg_start < message_size {


### PR DESCRIPTION
# Description

## Problem\*

closes https://github.com/noir-lang/sha256/issues/29

## Summary\*

We want to export the partial SHA-256 hash functions  to the public API.


## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
