### PR TITLE
chore: combine block building and verification functions

### DIFF
--- a/src/sha256.nr
+++ b/src/sha256.nr
@@ -209,7 +209,7 @@ pub(crate) unconstrained fn build_msg_block_helper<let N: u32>(
 // in that case we can skip verification, ie. no need to check that everything is zero.
 fn build_msg_block<let N: u32>(msg: [u8; N], message_size: u32, msg_start: u32) -> MSG_BLOCK {
     let msg_block =
-        // Safety: separate verification function
+        // Safety: We constrain the block below by reconstructing each `u32` word from the input bytes.
         unsafe { build_msg_block_helper(msg, message_size, msg_start) };
 
     if !is_unconstrained() {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR changes `verify_msg_block` so that it builds the new block internally

## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
