### PR TITLE
feat: remove zero padding check

### DIFF
--- a/src/sha256.nr
+++ b/src/sha256.nr
@@ -154,8 +154,7 @@ pub(crate) fn process_full_blocks<let N: u32>(
         blocks[num_blocks] = new_msg_block;
     }
 
-    let final_block = blocks[first_partially_filled_block_index];
-    (states[first_partially_filled_block_index], final_block)
+    (states[first_partially_filled_block_index], blocks[first_partially_filled_block_index])
 }
 
 // Take `BLOCK_SIZE` number of bytes from `msg` starting at `msg_start` and pack them into a `MSG_BLOCK`.


### PR DESCRIPTION
# Description

## Problem\*

To further optimize block verification, we can remove `verify_msg_block_zeros` fn from `process_full_blocks` since we are verifying each block in `build_msg_block`

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
