### PR TITLE
chore: allow manually dispatching the benchmarks workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,6 +5,7 @@ on:
    branches:
     - main
   pull_request:
+  workflow_dispatch:
 
 env:
   MINIMUM_NOIR_VERSION: 1.0.0-beta.15


### PR DESCRIPTION
## Description

In https://github.com/noir-lang/sha256/pull/62 we get a CI failure because benchmarks no longer exist for `main` because they are too old and they were deleted (expired). This PR lets us run that workflow manually. We could then merge this PR, run the workflow, and update #62 so we can see the benchmark results.